### PR TITLE
docs: add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Product overview
+
+**dicekit** is a Python library for modeling dice and urn draws with arbitrary probability distributions. Development is notebook-driven: the canonical implementation lives in `nbs/__init__.py`, exported to `dicekit/__init__.py` via `nbs/build.py`. There is no web API, database, or Docker stack.
+
+### Prerequisites
+
+- **Python 3.10–3.12** (see `requires-python` in `pyproject.toml`)
+- **uv** package manager (`curl -LsSf https://astral.sh/uv/install.sh | sh` if not on `PATH`)
+
+### Common commands
+
+See `Makefile` and `.github/workflows/tests.yml` for the canonical workflow:
+
+| Task | Command |
+|------|---------|
+| Install dev deps | `make install` |
+| Run tests | `make test` |
+| Rebuild lib + docs | `make build` |
+| Interactive notebook | `uv run marimo edit nbs/__init__.py --headless` |
+
+There is no dedicated linter in this repo; CI runs **pytest** only.
+
+### Marimo notebook server
+
+When starting marimo on `nbs/__init__.py`, it may prompt:
+
+> Run in a sandboxed venv containing this notebook's dependencies? [Y/n]
+
+Answer **`n`** when dependencies are already installed via `make install` (non-interactive: pipe `printf 'n\n'` or send `n` in tmux). Default URL: **http://localhost:2718** (token appended to URL when `--token` is enabled).
+
+### Static docs (optional)
+
+Pre-built WASM docs are in `docs/`. Serve locally with `python -m http.server 8080 -d docs` for docs-only validation.
+
+### Testing notes
+
+- Automated verification is `uv run pytest` (15 tests in `tests/test_basics.py`).
+- No external services or network calls are required for tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,17 +20,21 @@ See `Makefile` and `.github/workflows/tests.yml` for the canonical workflow:
 | Install dev deps | `make install` |
 | Run tests | `make test` |
 | Rebuild lib + docs | `make build` |
-| Interactive notebook | `uv run marimo edit nbs/__init__.py --headless` |
+| Interactive notebook | `uvx marimo -y edit nbs/__init__.py --headless` |
 
 There is no dedicated linter in this repo; CI runs **pytest** only.
 
 ### Marimo notebook server
 
-When starting marimo on `nbs/__init__.py`, it may prompt:
+Use the global **`-y` / `--yes`** flag for non-interactive startup (same pattern as `make build`, which runs `uvx marimo -y export ...`):
 
-> Run in a sandboxed venv containing this notebook's dependencies? [Y/n]
+```bash
+uvx marimo -y edit nbs/__init__.py --headless
+```
 
-Answer **`n`** when dependencies are already installed via `make install` (non-interactive: pipe `printf 'n\n'` or send `n` in tmux). Default URL: **http://localhost:2718** (token appended to URL when `--token` is enabled).
+`-y` auto-accepts the sandbox prompt and starts the server without tmux keystrokes or piping answers. Default URL: **http://localhost:2718** (token appended when `--token` is enabled).
+
+**Note:** `uv run marimo -y edit ...` can fail here because the sandbox re-invokes the project marimo and hits a version conflict. Prefer **`uvx marimo -y edit`** instead.
 
 ### Static docs (optional)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud–specific development guidance for future cloud agents working on this repo.

- Documents install/test/build commands (`make install`, `make test`, etc.)
- Notes marimo sandbox prompt behavior for non-interactive startup
- Clarifies that CI runs pytest only (no separate linter)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bec256c9-f9b1-46d0-9196-a6c8cb38df84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bec256c9-f9b1-46d0-9196-a6c8cb38df84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

