### PR TITLE
Fix sum() on lists of Dice objects

### DIFF
--- a/dicekit/__init__.py
+++ b/dicekit/__init__.py
@@ -202,10 +202,12 @@ class Dice:
         return Dice(result)
 
     def __add__(self, other):
+        if not isinstance(other, Dice) and other == 0:
+            return self
         return self.operate(other, lambda a, b: a + b)
 
     def __radd__(self, other):
-        if other == 0:
+        if not isinstance(other, Dice) and other == 0:
             return self
         return self.operate(other, lambda a, b: a + b)
 

--- a/dicekit/__init__.py
+++ b/dicekit/__init__.py
@@ -205,6 +205,8 @@ class Dice:
         return self.operate(other, lambda a, b: a + b)
 
     def __radd__(self, other):
+        if other == 0:
+            return self
         return self.operate(other, lambda a, b: a + b)
 
     def __sub__(self, other):

--- a/nbs/__init__.py
+++ b/nbs/__init__.py
@@ -414,6 +414,8 @@ def _():
             return self.operate(other, lambda a, b: a + b)
 
         def __radd__(self, other):
+            if other == 0:
+                return self
             return self.operate(other, lambda a, b: a + b)
 
         def __sub__(self, other):

--- a/nbs/__init__.py
+++ b/nbs/__init__.py
@@ -411,10 +411,12 @@ def _():
             return Dice(result)
 
         def __add__(self, other):
+            if not isinstance(other, Dice) and other == 0:
+                return self
             return self.operate(other, lambda a, b: a + b)
 
         def __radd__(self, other):
-            if other == 0:
+            if not isinstance(other, Dice) and other == 0:
                 return self
             return self.operate(other, lambda a, b: a + b)
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -61,6 +61,21 @@ def test_dice_mix_validates_arguments():
     with pytest.raises(ValueError, match="at least one"):
         mix()
 
+def test_dice_sum():
+    d6 = Dice.from_sides(6)
+    three_d6 = sum([d6, d6, d6])
+    assert three_d6.probs[10] == pytest.approx(27 / 216)
+    assert three_d6.probs[3] == pytest.approx(1 / 216)
+    assert sum([d6]).probs == d6.probs
+
+    labels = Dice({"a": 0.5, "b": 0.5})
+    assert sum([labels, labels]).probs == {
+        "aa": 0.25,
+        "ab": 0.25,
+        "ba": 0.25,
+        "bb": 0.25,
+    }
+
 def test_dice_reflected_operations():
     d = Dice({1: 0.5, 2: 0.5})
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -75,6 +75,11 @@ def test_dice_sum():
         "ba": 0.25,
         "bb": 0.25,
     }
+    assert (labels + 0).probs == labels.probs
+    assert (0 + labels).probs == labels.probs
+
+    d_with_zero = Dice({0: 0.5, 1: 0.5})
+    assert sum([d_with_zero, d_with_zero]).probs == {0: 0.25, 1: 0.5, 2: 0.25}
 
 def test_dice_reflected_operations():
     d = Dice({1: 0.5, 2: 0.5})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #2

## Problem

Python's built-in `sum()` starts from `0` and accumulates with `total = total + item`. For `Dice` objects, the first step calls `dice.__radd__(0)`. Without treating `0` as an additive identity, that step routes through `operate()` and tries to evaluate `outcome + 0` for every face. That works for numeric dice but fails for categorical outcomes (e.g. string faces).

## Solution

Short-circuit `__radd__` when `other == 0` and return `self` unchanged. This makes `sum([d1, d2, d3])` behave like chained addition.

## Tests

- `sum([d6, d6, d6])` matches known 3d6 probabilities
- `sum([d6])` returns the same distribution as a single die
- `sum([labels, labels])` works for categorical dice

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5bb2b44-51d4-4378-a0be-e3952939a49e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5bb2b44-51d4-4378-a0be-e3952939a49e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

