### PR TITLE
Speed up ordered stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Agent Instructions
+
+## Source Of Truth
+
+- `nbs/__init__.py` is the source notebook for exported package code.
+- `dicekit/__init__.py` is generated from exported cells in `nbs/__init__.py`.
+- Do not hand-edit only `dicekit/__init__.py` for package behavior changes. Update `nbs/__init__.py`, then run `make build`.
+
+## Validation
+
+- Run `make build` after changing exported notebook code.
+- Run `uv run pytest -q` before publishing changes.
+- Run `uv build` for release-prep changes.
+
+## Release Prep
+
+- Check the latest published version on PyPI before bumping `pyproject.toml`.
+- Keep `uv.lock` in sync with `pyproject.toml` by running `uv lock`.
+- Use the next available patch version for compatible fixes and performance improvements.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-# Claude Instructions
-
-Follow the repo guidance in `AGENTS.md`.
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Instructions
+
+Follow the repo guidance in `AGENTS.md`.

--- a/dicekit/__init__.py
+++ b/dicekit/__init__.py
@@ -199,7 +199,7 @@ class Dice:
         """
         items = [self] * n
         if k:
-            return ordered(*items)[:k]
+            return ordered(*items, k=k)
         return ordered(*items)
 
     def out_of(self, n=2, func=max):
@@ -342,7 +342,29 @@ def mix(*dice, weights=None):
     return Dice(new_probs)
 
 
-def ordered(*dice_in):
+def _slice_limit(length, stop):
+    return len(range(length)[:stop])
+
+
+def _threshold_probabilities(die, thresholds):
+    """
+    Return P(die >= threshold) for each threshold.
+    """
+    probabilities = {}
+    cumulative = 0
+    items = sorted(die.probs.items(), reverse=True)
+    item_index = 0
+
+    for threshold in thresholds:
+        while item_index < len(items) and items[item_index][0] >= threshold:
+            cumulative += items[item_index][1]
+            item_index += 1
+        probabilities[threshold] = cumulative
+
+    return probabilities
+
+
+def ordered(*dice_in, k=None):
     """
     Return dice that represent order statistics. Highest first.
 
@@ -355,23 +377,62 @@ def ordered(*dice_in):
     Returns:
         list: A list of Dice objects representing order statistics
     """
-    result = {}
-    for _i in product(*[d.probs.items() for d in dice_in]):
-        eyes = tuple(sorted([_[0] for _ in _i], reverse=True))
-        prob = reduce(lambda a, b: a * b, [_[1] for _ in _i])
-        if eyes not in result:
-            result[eyes] = 0
-        result[eyes] += prob
+    if not dice_in:
+        return []
 
-    dice_out = []
-    for _j in range(len(dice_in)):
-        new_dice = {}
-        for keys, pval in result.items():
-            if keys[_j] not in new_dice:
-                new_dice[keys[_j]] = 0
-            new_dice[keys[_j]] += pval
-        dice_out.append(Dice(new_dice))
-    return dice_out
+    n_dice = len(dice_in)
+    n_outputs = n_dice if k is None else _slice_limit(n_dice, k)
+    if n_outputs == 0:
+        return []
+
+    thresholds = sorted(
+        {outcome for die in dice_in for outcome in die.probs},
+        reverse=True,
+    )
+    probabilities = [
+        _threshold_probabilities(die, thresholds)
+        for die in dice_in
+    ]
+
+    dice_out = [{} for _ in range(n_outputs)]
+    higher_threshold_survival = [0] * (n_outputs + 1)
+
+    for threshold in thresholds:
+        pass_count_probs = [1] + [0] * n_outputs
+
+        for probability in probabilities:
+            p_ge = probability[threshold]
+            p_lt = 1 - p_ge
+            new_pass_count_probs = [0] * (n_outputs + 1)
+
+            for pass_count, pass_count_probability in enumerate(pass_count_probs):
+                if pass_count_probability == 0:
+                    continue
+                new_pass_count_probs[pass_count] += pass_count_probability * p_lt
+                capped_pass_count = min(pass_count + 1, n_outputs)
+                new_pass_count_probs[capped_pass_count] += (
+                    pass_count_probability * p_ge
+                )
+
+            pass_count_probs = new_pass_count_probs
+
+        survival = [0] * (n_outputs + 1)
+        running = 0
+        for pass_count in range(n_outputs, -1, -1):
+            running += pass_count_probs[pass_count]
+            survival[pass_count] = running
+
+        for order_index in range(n_outputs):
+            order = order_index + 1
+            probability = survival[order] - higher_threshold_survival[order]
+            if probability < 0 and abs(probability) < 1e-15:
+                probability = 0
+            if probability != 0:
+                dice_out[order_index][threshold] = probability
+
+        higher_threshold_survival = survival
+
+    return [Dice(probs) for probs in dice_out]
 
 
 

--- a/dicekit/__init__.py
+++ b/dicekit/__init__.py
@@ -269,6 +269,72 @@ class Dice:
 
 
 
+class Vase:
+    """
+    A collection of items that can be drawn to form a probability distribution.
+
+    A vase preserves repeated items and can model draws with or without
+    replacement, where the order of drawn items may optionally matter.
+    """
+
+    def __init__(self, contents):
+        """
+        Initialize a vase with the items it contains.
+
+        Parameters:
+            contents (list): Items available to draw from the vase
+        """
+        self._contents = contents
+
+    @classmethod
+    def from_counts(self, **kwargs):
+        """
+        Create a vase from item names and their quantities.
+
+        Parameters:
+            **kwargs (int): Item names mapped to the number of copies
+
+        Returns:
+            Vase: A vase containing the requested number of each item
+        """
+        contents = []
+        for k, v in kwargs.items():
+            contents.extend([k]*v)
+        return Vase(contents)
+
+    def _to_sorted_key(self, tup):
+        """
+        Convert a collection of items into an order-independent key.
+
+        Parameters:
+            tup (tuple): Items drawn from the vase
+
+        Returns:
+            str: The items sorted and joined into a single key
+        """
+        return "".join(sorted(tup))
+
+    def take(self, n=1, replace=False, ordered=False):
+        """
+        Calculate the distribution of drawing items from the vase.
+
+        Parameters:
+            n (int): Number of items to draw, default is 1
+            replace (bool): Whether drawn items are replaced, default is False
+            ordered (bool): Whether draw order affects outcomes, default is False
+
+        Returns:
+            Dice: The probability distribution over possible draws
+        """
+        if replace:
+            out = product(self._contents, repeat=n)
+        else:
+            out = permutations(self._contents, n)
+        out = [self._to_sorted_key(_) if not ordered else "".join(_) for _ in out]
+        return Dice(Counter(out))
+
+
+
 def p(expression):
     """
     Returns the probability of a True outcome from a dice expression.
@@ -433,69 +499,3 @@ def ordered(*dice_in, k=None):
         higher_threshold_survival = survival
 
     return [Dice(probs) for probs in dice_out]
-
-
-
-class Vase:
-    """
-    A collection of items that can be drawn to form a probability distribution.
-
-    A vase preserves repeated items and can model draws with or without
-    replacement, where the order of drawn items may optionally matter.
-    """
-
-    def __init__(self, contents):
-        """
-        Initialize a vase with the items it contains.
-
-        Parameters:
-            contents (list): Items available to draw from the vase
-        """
-        self._contents = contents
-
-    @classmethod
-    def from_counts(self, **kwargs):
-        """
-        Create a vase from item names and their quantities.
-
-        Parameters:
-            **kwargs (int): Item names mapped to the number of copies
-
-        Returns:
-            Vase: A vase containing the requested number of each item
-        """
-        contents = []
-        for k, v in kwargs.items():
-            contents.extend([k]*v)
-        return Vase(contents)
-
-    def _to_sorted_key(self, tup):
-        """
-        Convert a collection of items into an order-independent key.
-
-        Parameters:
-            tup (tuple): Items drawn from the vase
-
-        Returns:
-            str: The items sorted and joined into a single key
-        """
-        return "".join(sorted(tup))
-
-    def take(self, n=1, replace=False, ordered=False):
-        """
-        Calculate the distribution of drawing items from the vase.
-
-        Parameters:
-            n (int): Number of items to draw, default is 1
-            replace (bool): Whether drawn items are replaced, default is False
-            ordered (bool): Whether draw order affects outcomes, default is False
-
-        Returns:
-            Dice: The probability distribution over possible draws
-        """
-        if replace:
-            out = product(self._contents, repeat=n)
-        else:
-            out = permutations(self._contents, n)
-        out = [self._to_sorted_key(_) if not ordered else "".join(_) for _ in out]
-        return Dice(Counter(out))

--- a/nbs/__init__.py
+++ b/nbs/__init__.py
@@ -447,7 +447,7 @@ def _():
             """
             items = [self] * n
             if k:
-                return ordered(*items)[:k]
+                return ordered(*items, k=k)
             return ordered(*items)
 
         def out_of(self, n=2, func=max):
@@ -668,7 +668,29 @@ def _(Dice, product, reduce):
         return Dice(new_probs)
 
 
-    def ordered(*dice_in):
+    def _slice_limit(length, stop):
+        return len(range(length)[:stop])
+
+
+    def _threshold_probabilities(die, thresholds):
+        """
+        Return P(die >= threshold) for each threshold.
+        """
+        probabilities = {}
+        cumulative = 0
+        items = sorted(die.probs.items(), reverse=True)
+        item_index = 0
+
+        for threshold in thresholds:
+            while item_index < len(items) and items[item_index][0] >= threshold:
+                cumulative += items[item_index][1]
+                item_index += 1
+            probabilities[threshold] = cumulative
+
+        return probabilities
+
+
+    def ordered(*dice_in, k=None):
         """
         Return dice that represent order statistics. Highest first.
 
@@ -681,23 +703,62 @@ def _(Dice, product, reduce):
         Returns:
             list: A list of Dice objects representing order statistics
         """
-        result = {}
-        for _i in product(*[d.probs.items() for d in dice_in]):
-            eyes = tuple(sorted([_[0] for _ in _i], reverse=True))
-            prob = reduce(lambda a, b: a * b, [_[1] for _ in _i])
-            if eyes not in result:
-                result[eyes] = 0
-            result[eyes] += prob
+        if not dice_in:
+            return []
 
-        dice_out = []
-        for _j in range(len(dice_in)):
-            new_dice = {}
-            for keys, pval in result.items():
-                if keys[_j] not in new_dice:
-                    new_dice[keys[_j]] = 0
-                new_dice[keys[_j]] += pval
-            dice_out.append(Dice(new_dice))
-        return dice_out
+        n_dice = len(dice_in)
+        n_outputs = n_dice if k is None else _slice_limit(n_dice, k)
+        if n_outputs == 0:
+            return []
+
+        thresholds = sorted(
+            {outcome for die in dice_in for outcome in die.probs},
+            reverse=True,
+        )
+        probabilities = [
+            _threshold_probabilities(die, thresholds)
+            for die in dice_in
+        ]
+
+        dice_out = [{} for _ in range(n_outputs)]
+        higher_threshold_survival = [0] * (n_outputs + 1)
+
+        for threshold in thresholds:
+            pass_count_probs = [1] + [0] * n_outputs
+
+            for probability in probabilities:
+                p_ge = probability[threshold]
+                p_lt = 1 - p_ge
+                new_pass_count_probs = [0] * (n_outputs + 1)
+
+                for pass_count, pass_count_probability in enumerate(pass_count_probs):
+                    if pass_count_probability == 0:
+                        continue
+                    new_pass_count_probs[pass_count] += pass_count_probability * p_lt
+                    capped_pass_count = min(pass_count + 1, n_outputs)
+                    new_pass_count_probs[capped_pass_count] += (
+                        pass_count_probability * p_ge
+                    )
+
+                pass_count_probs = new_pass_count_probs
+
+            survival = [0] * (n_outputs + 1)
+            running = 0
+            for pass_count in range(n_outputs, -1, -1):
+                running += pass_count_probs[pass_count]
+                survival[pass_count] = running
+
+            for order_index in range(n_outputs):
+                order = order_index + 1
+                probability = survival[order] - higher_threshold_survival[order]
+                if probability < 0 and abs(probability) < 1e-15:
+                    probability = 0
+                if probability != 0:
+                    dice_out[order_index][threshold] = probability
+
+            higher_threshold_survival = survival
+
+        return [Dice(probs) for probs in dice_out]
 
     return exp, ordered, p, var
 

--- a/nbs/build.py
+++ b/nbs/build.py
@@ -4,12 +4,11 @@ from pathlib import Path
 
 # Lets move out the code first
 
-order = InternalApp(app).execution_order
-codes = {k: v.code for k, v in InternalApp(app).graph.cells.items() if v.language=="python" and "## Export" in v.code}
+cells = InternalApp(app).graph.cells
+codes = [v.code for v in cells.values() if v.language=="python" and "## Export" in v.code]
 
 code_export = ""
-for i in order:
-    if i in codes:
-        code_export += codes[i].replace("## Export", "") + "\n"
+for code in codes:
+    code_export += code.replace("## Export", "") + "\n"
 
 Path("dicekit/__init__.py").write_text(code_export)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dicekit"
-version = "0.2.0"
+version = "0.2.2"
 description="Domain specific environment for dice"
 requires-python = ">=3.12,<3.13"
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,5 +1,47 @@
 import pytest
+from itertools import product
 from dicekit import Dice, Vase, p, exp, mix, var, ordered
+
+
+def brute_force_ordered(*dice_in):
+    dice_out = [{} for _ in dice_in]
+    for combo in product(*[die.probs.items() for die in dice_in]):
+        outcomes = sorted([outcome for outcome, _ in combo], reverse=True)
+        probability = 1
+        for _, outcome_probability in combo:
+            probability *= outcome_probability
+        for index, outcome in enumerate(outcomes):
+            dice_out[index][outcome] = dice_out[index].get(outcome, 0) + probability
+    return [Dice(probs) for probs in dice_out]
+
+
+def old_method_ordered(*dice_in):
+    result = {}
+    for combo in product(*[die.probs.items() for die in dice_in]):
+        eyes = tuple(sorted([outcome for outcome, _ in combo], reverse=True))
+        probability = 1
+        for _, outcome_probability in combo:
+            probability *= outcome_probability
+        result[eyes] = result.get(eyes, 0) + probability
+
+    dice_out = []
+    for index in range(len(dice_in)):
+        new_dice = {}
+        for keys, probability in result.items():
+            new_dice[keys[index]] = new_dice.get(keys[index], 0) + probability
+        dice_out.append(Dice(new_dice))
+    return dice_out
+
+
+def assert_dice_probs_close(actual, expected):
+    assert len(actual) == len(expected)
+    for actual_dice, expected_dice in zip(actual, expected):
+        keys = set(actual_dice.probs) | set(expected_dice.probs)
+        for key in keys:
+            assert actual_dice.probs.get(key, 0) == pytest.approx(
+                expected_dice.probs.get(key, 0)
+            )
+
 
 def test_dice_creation():
     # Test basic dice creation
@@ -146,7 +188,7 @@ def test_dice_roll():
 def test_dice_ordered_2():
     d6 = Dice.from_sides(6)
     a1, a2 = ordered(d6, d6)
-    assert a1.probs[1] == 1/6/6
+    assert a1.probs[1] == pytest.approx(1/6/6)
     for k, v in a1.probs.items():
         assert abs(v - d6.out_of(2, max).probs[k]) < 1e-10
     for k, v in a2.probs.items():
@@ -155,7 +197,7 @@ def test_dice_ordered_2():
 def test_dice_ordered_method():
     d6 = Dice.from_sides(6)
     a1, a2 = d6.ordered(2)
-    assert a1.probs[1] == 1/6/6
+    assert a1.probs[1] == pytest.approx(1/6/6)
     for k, v in a1.probs.items():
         assert abs(v - d6.out_of(2, max).probs[k]) < 1e-10
     for k, v in a2.probs.items():
@@ -165,6 +207,15 @@ def test_dice_ordered_method():
     for k, v in highest.probs.items():
         assert abs(v - d6.out_of(2, max).probs[k]) < 1e-10
 
+def test_dice_ordered_method_limits_work_to_k_results():
+    d6 = Dice.from_sides(6)
+
+    first_two = d6.ordered(5, k=2)
+    all_ordered = d6.ordered(5)
+
+    assert len(first_two) == 2
+    assert_dice_probs_close(first_two, all_ordered[:2])
+
 def test_dice_ordered_3():
     d6 = Dice.from_sides(6)
     a1, _, a3 = ordered(d6, d6, d6)
@@ -173,3 +224,44 @@ def test_dice_ordered_3():
         assert abs(v - d6.out_of(3, max).probs[k]) < 1e-8
     for k, v in a3.probs.items():
         assert abs(v - d6.out_of(3, min).probs[k]) < 1e-8
+
+def test_dice_ordered_mixed_dice_matches_brute_force():
+    dice = [
+        Dice.from_sides(4),
+        Dice.from_sides(6),
+        Dice({1: 0.1, 5: 0.2, 9: 0.7}),
+    ]
+
+    assert_dice_probs_close(ordered(*dice), brute_force_ordered(*dice))
+
+def test_dice_ordered_mixed_dice_matches_old_method():
+    dice = [
+        Dice.from_sides(4),
+        Dice.from_sides(6),
+        Dice({1: 0.1, 5: 0.2, 9: 0.7}),
+        Dice({0: 2, 4: 1}),
+    ]
+
+    assert_dice_probs_close(ordered(*dice), old_method_ordered(*dice))
+
+def test_dice_ordered_sparse_faces_matches_brute_force():
+    dice = [
+        Dice({1: 1, 3: 2, 10: 1}),
+        Dice({3: 1, 10: 1}),
+        Dice({1: 4, 10: 1}),
+    ]
+
+    assert_dice_probs_close(ordered(*dice), brute_force_ordered(*dice))
+
+def test_dice_ordered_k_matches_prefix():
+    dice = [
+        Dice.from_sides(4),
+        Dice.from_sides(6),
+        Dice({1: 0.1, 5: 0.2, 9: 0.7}),
+    ]
+
+    first_two = ordered(*dice, k=2)
+    all_ordered = ordered(*dice)
+
+    assert len(first_two) == 2
+    assert_dice_probs_close(first_two, all_ordered[:2])

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -225,13 +225,28 @@ def test_dice_ordered_3():
     for k, v in a3.probs.items():
         assert abs(v - d6.out_of(3, min).probs[k]) < 1e-8
 
-def test_dice_ordered_mixed_dice_matches_brute_force():
-    dice = [
-        Dice.from_sides(4),
-        Dice.from_sides(6),
-        Dice({1: 0.1, 5: 0.2, 9: 0.7}),
-    ]
-
+@pytest.mark.parametrize(
+    "dice",
+    [
+        (
+            Dice.from_sides(4),
+            Dice.from_sides(6),
+            Dice({1: 0.1, 5: 0.2, 9: 0.7}),
+        ),
+        (
+            Dice({1: 1, 3: 2, 10: 1}),
+            Dice({3: 1, 10: 1}),
+            Dice({1: 4, 10: 1}),
+        ),
+        (
+            Dice.from_sides(3),
+            Dice({0: 1, 2: 2}),
+            Dice({1: 1, 4: 1}),
+            Dice({-1: 1, 5: 3}),
+        ),
+    ],
+)
+def test_dice_ordered_matches_brute_force(dice):
     assert_dice_probs_close(ordered(*dice), brute_force_ordered(*dice))
 
 def test_dice_ordered_mixed_dice_matches_old_method():
@@ -244,24 +259,16 @@ def test_dice_ordered_mixed_dice_matches_old_method():
 
     assert_dice_probs_close(ordered(*dice), old_method_ordered(*dice))
 
-def test_dice_ordered_sparse_faces_matches_brute_force():
-    dice = [
-        Dice({1: 1, 3: 2, 10: 1}),
-        Dice({3: 1, 10: 1}),
-        Dice({1: 4, 10: 1}),
-    ]
-
-    assert_dice_probs_close(ordered(*dice), brute_force_ordered(*dice))
-
-def test_dice_ordered_k_matches_prefix():
+@pytest.mark.parametrize("k", [1, 2, 3])
+def test_dice_ordered_k_matches_prefix(k):
     dice = [
         Dice.from_sides(4),
         Dice.from_sides(6),
         Dice({1: 0.1, 5: 0.2, 9: 0.7}),
     ]
 
-    first_two = ordered(*dice, k=2)
+    first_two = ordered(*dice, k=k)
     all_ordered = ordered(*dice)
 
-    assert len(first_two) == 2
-    assert_dice_probs_close(first_two, all_ordered[:2])
+    assert len(first_two) == k
+    assert_dice_probs_close(first_two, all_ordered[:k])

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ wheels = [
 
 [[package]]
 name = "dicekit"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "hastyplot" },


### PR DESCRIPTION
## Summary

Speed up ordered statistics by replacing Cartesian-product enumeration with exact threshold-based dynamic programming that works for mixed dice.

Update the notebook source of truth, make notebook exports deterministic, and add agent instructions so future changes run through `nbs/__init__.py` plus `make build`.

Prepare the package for a 0.2.2 release because PyPI already has dicekit 0.2.1 published.

## Validation

- uv run pytest -q
- uv build
- GitHub Actions: build and test (3.12)